### PR TITLE
Fix for issue #14.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,76 +1,103 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-facter",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GodepVersion": "v74",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
-			"Comment": "v0.7.3",
-			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+			"Comment": "v0.10.0-16-gcd7d1bb",
+			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
 		},
 		{
 			"ImportPath": "github.com/gopherjs/gopherjs/js",
 			"Rev": "4b53e1bddba0e2f734514aeb6c02db652f4c6fe8"
 		},
 		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/ns",
+			"Rev": "925bafffac36edcfaf4aff937dcb7d3d5659782d"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/str",
+			"Rev": "925bafffac36edcfaf4aff937dcb7d3d5659782d"
+		},
+		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/rpc",
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/grpc/common",
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.15.0-beta-37-g906d19b",
+			"Rev": "906d19b646837393f9893870cc2929e791b1f3fb"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",
 			"Comment": "v4.2.0",
 			"Rev": "8ddce2a84170772b95dd5d576c48d517b22cac63"
+		},
+		{
+			"ImportPath": "github.com/oleiade/reflections",
+			"Comment": "0.1.2-2-g632977f",
+			"Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
@@ -106,6 +133,70 @@
 			"ImportPath": "github.com/smartystreets/goconvey/convey/reporting",
 			"Comment": "1.6.0-10-g995f5b2",
 			"Rev": "995f5b2e021c69b8b028ba6d0b05c1dd500783db"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2/hpack",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/internal/timeseries",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/trace",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "7f918dd405547ecb864d14a8ecbbfe205b5f930f"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/codes",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/credentials",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/grpclog",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/internal",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/metadata",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/naming",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/peer",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/transport",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/facter/facter_integration_test.go
+++ b/facter/facter_integration_test.go
@@ -27,6 +27,7 @@ package facter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,14 +52,14 @@ func TestFacterCollectMetrics(t *testing.T) {
 			return facts{someFact: someValue}, nil
 		}
 
-		Convey("asked for nothgin returns nothing", func() {
+		Convey("asked for nothing returns nothing", func() {
 			metricTypes := []plugin.MetricType{}
 			metrics, err := f.CollectMetrics(metricTypes)
 			So(err, ShouldBeNil)
 			So(metrics, ShouldBeEmpty)
 		})
 
-		Convey("asked for somehting returns something", func() {
+		Convey("asked for something returns something", func() {
 			metricTypes := []plugin.MetricType{
 				plugin.MetricType{
 					Namespace_: existingNamespace,
@@ -162,6 +163,7 @@ func TestFacterGetMetricsTypes(t *testing.T) {
 	Convey("GetMetricTypes functionallity", t, func() {
 
 		f := NewFacterCollector()
+		So(f, ShouldNotBeNil)
 
 		Convey("GetMetricsTypes returns no error", func() {
 			// executes without error
@@ -186,6 +188,36 @@ func TestFacterGetMetricsTypes(t *testing.T) {
 					t.Error("It was expected to find at least on intel/facter/kernel metricType (but it wasn't there)")
 				}
 			})
+
+			Convey("Then list of metrics is returned", func() {
+				So(len(metricTypes), ShouldNotBeNil)
+				namespaces := []string{}
+				for _, m := range metricTypes {
+					namespaces = append(namespaces, strings.Join(m.Namespace().Strings(), "/"))
+				}
+
+				So(namespaces, ShouldContain, "intel/facter/timezone")
+				So(namespaces, ShouldContain, "intel/facter/operatingsystem")
+				So(namespaces, ShouldContain, "intel/facter/blockdevices")
+				So(namespaces, ShouldContain, "intel/facter/uptime_seconds")
+				So(namespaces, ShouldContain, "intel/facter/id")
+				So(namespaces, ShouldContain, "intel/facter/osfamily")
+				So(namespaces, ShouldContain, "intel/facter/kernelrelease")
+				So(namespaces, ShouldContain, "intel/facter/facterversion")
+				So(namespaces, ShouldContain, "intel/facter/hardwaremodel")
+				So(namespaces, ShouldContain, "intel/facter/hostname")
+				So(namespaces, ShouldContain, "intel/facter/memorysize")
+				So(namespaces, ShouldContain, "intel/facter/interfaces")
+				So(namespaces, ShouldContain, "intel/facter/ipaddress")
+				So(namespaces, ShouldContain, "intel/facter/kernel")
+				So(namespaces, ShouldContain, "intel/facter/os/name")
+				So(namespaces, ShouldContain, "intel/facter/physicalprocessorcount")
+				So(namespaces, ShouldContain, "intel/facter/memorysize_mb")
+				So(namespaces, ShouldContain, "intel/facter/kernelmajversion")
+				So(namespaces, ShouldContain, "intel/facter/kernelrelease")
+				So(namespaces, ShouldContain, "intel/facter/processors/models/0")
+			})
 		})
+
 	})
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,22 @@
 #!/bin/bash -e
 
+#http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+#Copyright 2015 Intel Corporation
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 GITVERSION=`git describe --always`
 SOURCEDIR=$1
 BUILDDIR=$SOURCEDIR/build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,22 @@
 #!/bin/bash -e
+
+#http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+#Copyright 2015 Intel Corporation
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. goimports     (https://github.com/bradfitz/goimports)


### PR DESCRIPTION
Problem that occurred was that for some kind of metrics facter tool returned nested map instead of simple type value (string, float). So the response could not be encoded in here https://github.com/intelsdi-x/snap/blob/8539f5ac78cc75b7b1e6b8cc31934ce48c4bd534/control/plugin/collector_proxy.go#L99 without prior registration. 

The implemented fix solves this issue by parsing map returned by facter into several different metrics.
i.e. When requested metric is "/intel/facter/os", facter returns "map:[release:map[major:7 minor:2 full:7.2.1511] name:CentOS family:RedHat]".
This value is then parsed into several metrics:
/intel/facter/os/name CentOS
/intel/facter/os/family RedHat
/intel/facter/os/release/major 7
/intel/facter/os/release/minor 2
/intel/facter/os/release/full 7.2.1511

**Note: this fix uses updated snap-plugin-utilities GetValueByNamespace function.**

Changes in code:
- Implementation of solution - when facter returns map instead of a value, the map is being parsed into several metrics.
- Unit tests updated
- License added
- Version bumped
- Godeps updated

